### PR TITLE
Remove echo-api traces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,12 +102,6 @@ curl-web.app: export USER_KEY?=$(WEB_KEY)
 curl-web.app: ## Perform a curl call to web.app (make sure to export secrets)
 	$(MAKE) curl
 
-.PHONY: curl-echo-api.app
-curl-echo-api.app: export HOST?=echo-api.app
-curl-echo-api.app: export USER_KEY?=$(ECHO_API_KEY)
-curl-echo-api.app: ## Perform a curl call to echo-api.app (make sure to export secrets)
-	$(MAKE) curl
-
 # Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 .PHONY: help
 help: ## Print this help

--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ To run the demo:
 4. Create a `secrets` file with the following contents:
 ```shell
 export WEB_KEY=<a user_key for the service handling the web.app backend>
-export ECHO_API_KEY=<a user_key for the service handling the echo-api.app backend>
 ```
 5. Run `source secrets`.
-6. Run `make curl-web.app` or `make curl-echo-api.app`.
+6. Run `make curl-web.app`.
 6.1 Optionally specify a path to hit a specific pattern rule: `make SVC_PATH=products/1/sales curl-web.app` (N.B. no initial slash!)
 
 If you set up limits, those should be respected by this plug-in, and reporting

--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -21,30 +21,13 @@ services:
     networks:
       - ingress
       - mesh
-
-  echo-api:
-    image: quay.io/3scale/echoapi:stable
-    expose:
-      - "9292"
-    ports:
-      - "9292"
-    scale: 2
-    domainname: "app"
-    networks:
-      ingress:
-      mesh:
-        aliases:
-          - echo-api.app
-          - echoapi
-          - echoapi.app
-
   web:
     image: katacoda/docker-http-server
     expose:
       - "80"
     ports:
       - "80"
-    scale: 4
+    scale: 1
     domainname: "app"
     networks:
       mesh:

--- a/compose/envoy/envoy.yaml
+++ b/compose/envoy/envoy.yaml
@@ -23,27 +23,7 @@ static_resources:
                     socket_address:
                       address: web
                       port_value: 80
-
-    - name: echo-api
-      connect_timeout: 1.0s
-      type: logical_dns
-      dns_refresh_rate: 60s
-      lb_policy: round_robin
-      upstream_connection_options:
-        # configure a TCP keep-alive to detect and reconnect to the admin
-        # server in the event of a TCP socket half open connection
-        tcp_keepalive: {}
-      load_assignment:
-        cluster_name: echo-api
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  address:
-                    socket_address:
-                      address: echo-api
-                      port_value: 9292
-
-    - name: 3scale-saas-backend
+    - name: outbound|443||su1.3scale.net
       connect_timeout: 2.0s
       type: logical_dns
       dns_refresh_rate: 60s
@@ -53,7 +33,7 @@ static_resources:
         # server in the event of a TCP socket half open connection
         tcp_keepalive: {}
       load_assignment:
-        cluster_name: 3scale-saas-backend
+        cluster_name: outbound|443||su1.3scale.net
         endpoints:
           - lb_endpoints:
               - endpoint:
@@ -66,6 +46,29 @@ static_resources:
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: su1.3scale.net
+    - name: outbound|443||multitenant.3scale.net
+      connect_timeout: 2.0s
+      type: logical_dns
+      dns_refresh_rate: 60s
+      lb_policy: round_robin
+      upstream_connection_options:
+        # configure a TCP keep-alive to detect and reconnect to the admin
+        # server in the event of a TCP socket half open connection
+        tcp_keepalive: {}
+      load_assignment:
+        cluster_name: outbound|443||multitenant.3scale.net
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: multitenant.3scale.net
+                      port_value: 443
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: multitenant.3scale.net
 
 admin:
   access_log_path: /dev/stdout

--- a/compose/envoy/lds.yaml
+++ b/compose/envoy/lds.yaml
@@ -30,17 +30,6 @@ resources:
                           prefix: "/"
                         route:
                           cluster: web
-                  - name: echo-api_backend
-                    domains:
-                      - echo-api
-                      - echo-api.app
-                      - echoapi
-                      - echoapi.app
-                    routes:
-                      - match:
-                          prefix: "/"
-                        route:
-                          cluster: echo-api
               http_filters:
                 - name: envoy.filters.http.wasm
                   typed_config:
@@ -66,23 +55,23 @@ resources:
                           {
                             "system": {
                               "upstream": {
-                                "name": "a_cluster",
-                                "url": "https://a-system-url",
+                                "name": "outbound|443||multitenant.3scale.net",
+                                "url": "https://istiodevel-admin.3scale.net",
                                 "timeout": 5000
                               },
-                              "token": "a system token"
+                              "token": "invalid-token"
                             },
                             "backend": {
                               "upstream": {
-                                "name": "3scale-saas-backend",
+                                "name": "outbound|443||su1.3scale.net",
                                 "url": "https://su1.3scale.net",
                                 "timeout": 5000
                               }
                             },
                             "services": [
                               {
-                                "id": "web_svc_id",
-                                "token": "web_svc_token",
+                                "id": "2555417834780",
+                                "token": "invalid-token",
                                 "authorities": [
                                   "web",
                                   "web.app"
@@ -110,42 +99,10 @@ resources:
                                   },
                                   {
                                     "method": "get",
-                                    "pattern": "/ticks",
+                                    "pattern": "/productpage",
                                     "usages": [
                                       {
                                         "name": "ticks",
-                                        "delta": 1
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "id": "echo_svc_id",
-                                "token": "echo_svc_token",
-                                "authorities": [
-                                  "echo-api",
-                                  "echo-api.app",
-                                  "echoapi",
-                                  "echoapi.app"
-                                ],
-                                "credentials": [
-                                  {
-                                    "kind": "user_key",
-                                    "key": "x-api-key",
-                                    "locations": [
-                                      "header",
-                                      "query_string"
-                                    ]
-                                  }
-                                ],
-                                "mapping_rules": [
-                                  {
-                                    "method": "get",
-                                    "pattern": "/",
-                                    "usages": [
-                                      {
-                                        "name": "hits",
                                         "delta": 1
                                       }
                                     ]


### PR DESCRIPTION
We plan to use just the sample web app and in the case of Istio the bookinfo app. This removes extra configuration and make targets that are not currently providing much value for testing that the module is working correctly.

While at it, we also switch to using cluster names used by Istio (since we can name them however we want outside it as well) in preparation for supporting it.