### PR TITLE
upstream: add scheme and log it

### DIFF
--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -37,6 +37,7 @@ impl Upstream {
         self.base_path.as_deref()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn call<C: proxy_wasm::traits::Context>(
         &self,
         ctx: &C,
@@ -55,7 +56,7 @@ impl Upstream {
 
         let mut hdrs = vec![
             (":authority", self.authority.as_str()),
-            (":method", method.as_ref()),
+            (":method", method),
             (":path", path.as_str()),
         ];
 
@@ -108,8 +109,8 @@ impl TryFrom<url::Url> for UpstreamBuilder {
     type Error = anyhow::Error;
 
     fn try_from(url: url::Url) -> Result<Self, Self::Error> {
-        let authority =
-            crate::url::authority(&url).ok_or(anyhow!("url does not contain an authority"))?;
+        let authority = crate::url::authority(&url)
+            .ok_or_else(|| anyhow!("url does not contain an authority"))?;
         Ok(UpstreamBuilder { url, authority })
     }
 }

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -10,6 +10,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 1000u64;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Upstream {
     name: String,
+    scheme: String,
     authority: String,
     base_path: Option<String>,
     // timeout in ms
@@ -27,6 +28,10 @@ impl Upstream {
 
     pub fn name(&self) -> &str {
         self.name.as_str()
+    }
+
+    pub fn scheme(&self) -> &str {
+        self.scheme.as_str()
     }
 
     pub fn authority(&self) -> &str {
@@ -55,7 +60,8 @@ impl Upstream {
         }
 
         let mut hdrs = vec![
-            (":authority", self.authority.as_str()),
+            (":authority", self.authority()),
+            (":scheme", self.scheme()),
             (":method", method),
             (":path", path.as_str()),
         ];
@@ -63,6 +69,13 @@ impl Upstream {
         hdrs.extend(headers);
 
         let trailers = trailers.unwrap_or_default();
+        log::debug!(
+            "calling out {} (using {} scheme) with headers -> {:?} <- and body -> {:?} <-",
+            self.name(),
+            self.scheme(),
+            hdrs,
+            body
+        );
         ctx.dispatch_http_call(
             self.name.as_str(),
             hdrs,
@@ -74,7 +87,8 @@ impl Upstream {
         )
         .map_err(|e| {
             anyhow!(
-                "failed to dispatch HTTP call to cluster {} with authority {}: {:?}",
+                "failed to dispatch HTTP ({}) call to cluster {} with authority {}: {:?}",
+                self.scheme,
                 self.name,
                 self.authority,
                 e
@@ -91,6 +105,7 @@ pub struct UpstreamBuilder {
 impl UpstreamBuilder {
     pub fn build(self, name: impl ToString, timeout: Option<u64>) -> Upstream {
         let name = name.to_string();
+        let scheme = self.url.scheme().to_string();
         let base_path = match self.url.path() {
             "/" => None,
             path => path.to_string().into(),
@@ -98,6 +113,7 @@ impl UpstreamBuilder {
 
         Upstream {
             name,
+            scheme,
             authority: self.authority,
             base_path,
             timeout: Duration::from_millis(timeout.unwrap_or(DEFAULT_TIMEOUT_MS)),


### PR DESCRIPTION
This will log the detected URL scheme for the 3scale Service Management API to be used, and will communicate it to the proxy so mismatches can be detected more easily (ie. debug mode in Envoy will print the _effective_ scheme).